### PR TITLE
Ignore weak subj

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -35,6 +35,7 @@ FLAGS="--network=$NETWORK \
     --metrics-port=8008 \
     --metrics-host-allowlist=* \
     --log-destination=CONSOLE \
+    --ignore-weak-subjectivity-period-enabled \
     --validators-proposer-default-fee-recipient=$VALID_FEE_RECIPIENT $CHECKPOINT_SYNC_FLAG $MEVBOOST_FLAG $EXTRA_OPTS"
 
 echo "[INFO - entrypoint] Starting beacon with flags: $FLAGS"


### PR DESCRIPTION
If teku has a db initialized when starting, and db latest block is from a long  time ago, teku will panic if flag `--ignore-weak-subjectivity-period-enabled` is not set

```
2024-10-30 12:51:53.593 INFO  - Initializing storage
2024-10-30 12:51:55.839 INFO  - Storage initialization complete
2024-10-30 12:51:55.839 WARN  - Not loading specified initial state as chain data already exists.
2024-10-30 12:51:56.180 FATAL - Teku failed to start
java.util.concurrent.CompletionException: java.lang.IllegalStateException: Cannot sync outside of weak subjectivity period. Consider re-syncing your node using --checkpoint-sync-url or use --ignore-weak-subjectivity-period-enabled to ignore this check.
```