### PR TITLE
downgrade to 24.8.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "ConsenSys/teku",
-      "version": "24.10.3",
+      "version": "24.8.0",
       "arg": "UPSTREAM_VERSION"
     }
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: 24.10.3
+        UPSTREAM_VERSION: 24.8.0
         STAKER_SCRIPTS_VERSION: v0.1.0
         DATA_DIR: /opt/teku/data
     environment:
@@ -19,7 +19,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: 24.10.3
+        UPSTREAM_VERSION: 24.8.0
         STAKER_SCRIPTS_VERSION: v0.1.0
         DATA_DIR: /opt/teku/data
     environment:


### PR DESCRIPTION
24.10.3 teku version asks geth for some methods not yet supported. see https://discord.com/channels/@me/905843103477411861/1303815603538104330

for now, we will use 24.8.0 version. It has been working on testnet