### PR TITLE
bump ConsenSys/teku to 26.3.0, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "ConsenSys/teku",
-      "version": "25.11.1",
+      "version": "26.3.0",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: 25.11.1
+        UPSTREAM_VERSION: 26.3.0
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /opt/teku/data
     environment:
@@ -19,7 +19,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: 25.11.1
+        UPSTREAM_VERSION: 26.3.0
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /opt/teku/data
     environment:

--- a/package_variants/gnosis/dappnode_package.json
+++ b/package_variants/gnosis/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "teku-gnosis.dnp.dappnode.eth",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "requirements": {
     "minimumDappnodeVersion": "0.3.12"
   },

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "teku.dnp.dappnode.eth",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "links": {
     "ui": "http://brain.web3signer.dappnode",
     "homepage": "https://docs.teku.consensys.net",


### PR DESCRIPTION
Bumps upstream version

- [ConsenSys/teku](https://github.com/ConsenSys/teku) from 25.11.1 to [26.3.0](https://github.com/ConsenSys/teku/releases/tag/26.3.0)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)