### PR TITLE
fix: update LUKSO version and bootnodes

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -3,12 +3,19 @@
 CHECKPOINT_SYNC_KEY="--checkpoint-sync-url"
 MEVBOOST_FLAG_KEYS="--builder-endpoint"
 
+# https://github.com/lukso-network/network-configs/blob/main/mainnet/teku/teku.yaml
+LUKSO_BOOTNODES="enr:-MK4QHcS3JeTtVjOuJyVXvO1E6XJWqiwmhLfodel6vARPI8ve_2q9vVn8LpIL964qBId7zGpSVKw6oOPAaRm2H7ywYiGAYmHDeBbh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA2ulfbQgAABP__________gmlkgnY0gmlwhCIgwNOJc2VjcDI1NmsxoQNGVC8JPcsqsZPoohLP1ujAYpBfS0dBwiz4LeoUQ-k5OohzeW5jbmV0cwCDdGNwgjLIg3VkcIIu4A,enr:-Ly4QF7f-m7CiC1EwxmEa3VosxSUAeBaegcOek-J2DgqkB9EHyo5UOCZKAKuGN3pt3S28HVZy1PS6CGILRa8h25pZCsFh2F0dG5ldHOI__________-EZXRoMpCq3eQ4QgAABv__________gmlkgnY0gmlwhLJobp6Jc2VjcDI1NmsxoQJ88Tw_HsGhSdHp8AflKAJnt7VyHNDakc57AT6jdaBihIhzeW5jbmV0cw-DdGNwgiMog3VkcIIjKA,enr:-Jq4QABOsAAluqXVlLuAAWcMtYF__YTHcAWCChtvzXYa2GMuB5bEFaRnsoCuXUHTx4hxABFwwG29eQd3vH4GCZQbgdEBhGV0aDKQ3FGxEUIAAASkHwAAAAAAAIJpZIJ2NIJpcIQ5gLgeiXNlY3AyNTZrMaECWsDTDT1LTmpENdKPc6IbbViy5D1mahB4AJnPOCafYjKDdWRwgiMy"
+
 # shellcheck disable=SC1091 # Path is relative to the Dockerfile
 . /etc/profile
 
 ENGINE_URL="http://execution.${NETWORK}.staker.dappnode:8551"
 VALID_FEE_RECIPIENT=$(get_valid_fee_recipient "${FEE_RECIPIENT_ADDRESS}")
 MEVBOOST_FLAG=$(get_mevboost_flag "${NETWORK}" "${MEVBOOST_FLAG_KEYS}")
+
+if [ "${NETWORK}" = "lukso" ]; then
+    LUKSO_BOOTNODES_FLAG="--p2p-discovery-bootnodes=$LUKSO_BOOTNODES"
+fi
 
 if [ -n "${CHECKPOINT_SYNC_URL}" ]; then
     TEKU_FORMAT_CHECKPOINT_URL="$(echo "${CHECKPOINT_SYNC_URL}" | sed 's:/*$::')"
@@ -35,7 +42,7 @@ FLAGS="--network=$NETWORK \
     --metrics-port=8008 \
     --metrics-host-allowlist=* \
     --log-destination=CONSOLE \
-    --validators-proposer-default-fee-recipient=$VALID_FEE_RECIPIENT $CHECKPOINT_SYNC_FLAG $MEVBOOST_FLAG $EXTRA_OPTS"
+    --validators-proposer-default-fee-recipient=$VALID_FEE_RECIPIENT $LUKSO_BOOTNODES_FLAG $CHECKPOINT_SYNC_FLAG $MEVBOOST_FLAG $EXTRA_OPTS"
 
 echo "[INFO - entrypoint] Starting beacon with flags: $FLAGS"
 

--- a/package_variants/lukso/dappnode_package.json
+++ b/package_variants/lukso/dappnode_package.json
@@ -1,6 +1,13 @@
 {
   "name": "teku-lukso.dnp.dappnode.eth",
   "version": "0.1.4",
+  "upstream": [
+    {
+      "repo": "ConsenSys/teku",
+      "version": "26.2.0",
+      "arg": "UPSTREAM_VERSION"
+    }
+  ],
   "links": {
     "ui": "http://brain.web3signer-lukso.dappnode",
     "homepage": "https://docs.teku.consensys.net",

--- a/package_variants/lukso/docker-compose.yml
+++ b/package_variants/lukso/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       args:
         NETWORK: lukso
         P2P_PORT: 9905
+        UPSTREAM_VERSION: 26.2.0
     environment:
       CHECKPOINT_SYNC_URL: "https://checkpoint-sync-lukso.dappnode.net"
     ports:
@@ -16,5 +17,6 @@ services:
     build:
       args:
         NETWORK: lukso
+        UPSTREAM_VERSION: 26.2.0
 volumes:
   teku-lukso-data: {}


### PR DESCRIPTION
## Summary

- Pin both LUKSO beacon and validator services to the officially supported Teku `26.2.0` release.
- Pass the current three LUKSO consensus bootnodes explicitly, overriding the stale entries embedded by `--network=lukso`.
- Keep the variant manifest metadata aligned with both Docker build arguments.

## Validation

- DAppNode SDK manifest and compose validation passed.
- The merged LUKSO Docker Compose build completed successfully.
- Both built binaries report Teku `26.2.0`.
- The packaged bootnode list exactly matches the official LUKSO configuration.